### PR TITLE
Enable ruff formatting and linting pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+
+- repo: https://github.com/astral-sh/uv-pre-commit
+  rev: 0.4.20
+  hooks:
+    - id: uv-lock
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.7.1
+  hooks:
+    - id: ruff
+      args: [--fix-only, --exit-non-zero-on-fix]
+    - id: ruff-format

--- a/ir_remote/launchremote.py
+++ b/ir_remote/launchremote.py
@@ -11,24 +11,21 @@ except Exception as ex:
     print("Error" + str(ex))
     sys.exit()
 
-              
-class launchremote:           
 
+class launchremote:
     def __init__(self):
-
-        #load remoteLog
+        # load remoteLog
         self.loadremoteLog()
-        
-        #load remote
+
+        # load remote
         self.loadRemote()
 
-        #load mqtt
+        # load mqtt
         self.loadMqtt()
-            
-        #launch webserver
+
+        # launch webserver
         self.loadWebserver()
-        
-        
+
     def loadremoteLog(self):
         self.remoteLog = remoteLog()
 
@@ -37,24 +34,24 @@ class launchremote:
         deviceList = self.remote.deviceList
         self.mqtt.run(deviceList)
         self.mqtt.remoteHass()
-        self.mqtt.client.on_message = self.mqttMessage 
+        self.mqtt.client.on_message = self.mqttMessage
 
     def loadRemote(self):
         self.remote = remote()
         self.remote.activeRemote.keyPress = self.webserverkeypress
         self.remote.activeRemote.updateConfig = self.webserverUpdate
         self.remote.activeRemote.switchDevice = self.webserverSwitch
-            
-    def loadWebserver(self):     
+
+    def loadWebserver(self):
         self.mywebserver = flaskWrapper(self.remote.activeRemote)
         self.mywebserver.run()
 
     def mqttMessage(self, client, userdata, msg):
         data = msg.payload.decode()
-        device = data.split(':', 1)[0]
-        key = data.split(':', 1)[-1] 
+        device = data.split(":", 1)[0]
+        key = data.split(":", 1)[-1]
         self.remoteLog.info("-------MQTT Button-------")
-        self.remoteLog.info("Button Pressed: "+key+"")
+        self.remoteLog.info("Button Pressed: " + key + "")
         self.remote.send(device, key)
 
     def webserverkeypress(self, key):
@@ -64,31 +61,21 @@ class launchremote:
 
     def webserverUpdate(self, device, data):
         self.remoteLog.info("-------Saving config-------")
-        self.remoteLog.info("Remote: "+self.remote.activeRemote.active+"")
+        self.remoteLog.info("Remote: " + self.remote.activeRemote.active + "")
         self.remote.update(device, data)
         self.remoteLog.info("Saved Successfully")
 
     def webserverSwitch(self, name):
         self.remoteLog.info("-------Switching Device-------")
-        self.remoteLog.info("New Device: "+name+"")
+        self.remoteLog.info("New Device: " + name + "")
         self.remote.load(name)
         self.remoteLog.info("Switched Successfully")
+
 
 def run():
     remote = launchremote()
 
+
 if __name__ == "__main__":
-        
-    #Start IR Remote
+    # Start IR Remote
     run()
-        
-
-            
-            
-
-
-        
-
-        
-    
-    

--- a/ir_remote/mqtt.py
+++ b/ir_remote/mqtt.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python3
 
-import sys, os, time, json
+import sys
+import time
+import json
 import paho.mqtt.client as mqtt
 
 try:
@@ -11,17 +13,16 @@ except Exception as ex:
 
 
 class remoteMqtt:
-
-    def __init__(self): 
-        self.remoteLog = remoteLog()  
-        self.remoteLog.info("-------Launching MQTT-------")  
-        self.broker = 'localhost'
+    def __init__(self):
+        self.remoteLog = remoteLog()
+        self.remoteLog.info("-------Launching MQTT-------")
+        self.broker = "localhost"
         self.port = 1883
-        self.client_id = 'irRemote-mqtt-bridge'  
+        self.client_id = "irRemote-mqtt-bridge"
 
-    def run(self, deviceList):       
+    def run(self, deviceList):
         mqtt.Client.connected_flag = False
-        mqtt.Client.bad_connection_flag=False
+        mqtt.Client.bad_connection_flag = False
         self.client = mqtt.Client()
         self.client.on_connect = self.on_connect
         self.client.loop_start()
@@ -37,123 +38,124 @@ class remoteMqtt:
         for device in deviceList:
             self.haDiscovery(device)
 
-        #self.remoteHass()
+        # self.remoteHass()
 
     def haDiscovery(self, remote):
-
         self.remoteLog.info("-------Start MQTT Discovery-------")
-        self.remoteLog.info("Remote: "+remote+"")
-        make = remote.split('_', 1)[0]
-        model = remote.split('_', 1)[-1]  
+        self.remoteLog.info("Remote: " + remote + "")
+        make = remote.split("_", 1)[0]
+        model = remote.split("_", 1)[-1]
 
-
-        #Power button
-        discoveryMsg = {"name": "Power",
-            "command_topic":"IR-Remote/"+remote+"/pwr/set",
-            "payload_press":""+remote+":Power",
-            "unique_id":""+remote+"",
+        # Power button
+        discoveryMsg = {
+            "name": "Power",
+            "command_topic": "IR-Remote/" + remote + "/pwr/set",
+            "payload_press": "" + remote + ":Power",
+            "unique_id": "" + remote + "",
             "icon": "mdi:power",
             "device": {
                 "name": remote,
-                "model": ""+model+"",
-                "manufacturer": ""+make+"",
+                "model": "" + model + "",
+                "manufacturer": "" + make + "",
                 "identifiers": remote,
-                }
-            } 
-        
-        self.publish("homeassistant/button/"+remote+"/config", json.dumps(discoveryMsg))
-        self.subscribe("IR-Remote/"+remote+"/pwr/set")
+            },
+        }
 
-        #CH + button
-        discoveryMsg = {"name": "Ch +",
-            "command_topic":"IR-Remote/"+remote+"/chup/set",
-            "payload_press":""+remote+":Ch +",
-            "unique_id":"ChUp"+remote+"",
+        self.publish(
+            "homeassistant/button/" + remote + "/config", json.dumps(discoveryMsg)
+        )
+        self.subscribe("IR-Remote/" + remote + "/pwr/set")
+
+        # CH + button
+        discoveryMsg = {
+            "name": "Ch +",
+            "command_topic": "IR-Remote/" + remote + "/chup/set",
+            "payload_press": "" + remote + ":Ch +",
+            "unique_id": "ChUp" + remote + "",
             "icon": "mdi:plus",
-            "device": {
-                
-                "identifiers": remote
-                }
-            } 
+            "device": {"identifiers": remote},
+        }
 
-        self.publish("homeassistant/button/"+remote+"_chup/config", json.dumps(discoveryMsg))
-        self.subscribe("IR-Remote/"+remote+"/chup/set")
+        self.publish(
+            "homeassistant/button/" + remote + "_chup/config", json.dumps(discoveryMsg)
+        )
+        self.subscribe("IR-Remote/" + remote + "/chup/set")
 
-        #Ch - button
-        discoveryMsg = {"name": "Ch -",
-            "command_topic":"IR-Remote/"+remote+"/chdwn/set",
-            "payload_press":""+remote+":Ch -",
-            "unique_id":"chdwn_"+remote+"",
+        # Ch - button
+        discoveryMsg = {
+            "name": "Ch -",
+            "command_topic": "IR-Remote/" + remote + "/chdwn/set",
+            "payload_press": "" + remote + ":Ch -",
+            "unique_id": "chdwn_" + remote + "",
             "icon": "mdi:minus",
-            "device": {
-                
-                "identifiers": remote
-                }
-            } 
+            "device": {"identifiers": remote},
+        }
 
-        self.publish("homeassistant/button/"+remote+"_chdwn/config", json.dumps(discoveryMsg))
-        self.subscribe("IR-Remote/"+remote+"/chdwn/set")
+        self.publish(
+            "homeassistant/button/" + remote + "_chdwn/config", json.dumps(discoveryMsg)
+        )
+        self.subscribe("IR-Remote/" + remote + "/chdwn/set")
 
-        #Vol + button
-        discoveryMsg = {"name": "Vol +",
-            "command_topic":"IR-Remote/"+remote+"/volup/set",
-            "payload_press":""+remote+":Vol +",
-            "unique_id":"volup_"+remote+"",
+        # Vol + button
+        discoveryMsg = {
+            "name": "Vol +",
+            "command_topic": "IR-Remote/" + remote + "/volup/set",
+            "payload_press": "" + remote + ":Vol +",
+            "unique_id": "volup_" + remote + "",
             "icon": "mdi:volume-plus",
-            "device": {
-                
-                "identifiers": remote
-                }
-            } 
-        
-        self.publish("homeassistant/button/"+remote+"_volup/config", json.dumps(discoveryMsg))
-        self.subscribe("IR-Remote/"+remote+"/volup/set")
+            "device": {"identifiers": remote},
+        }
 
-        #Vol - button
-        discoveryMsg = {"name": "Vol -",
-            "command_topic":"IR-Remote/"+remote+"/voldwn/set",
-            "payload_press":""+remote+":Vol -",
-            "unique_id":"voldwn_"+remote+"",
+        self.publish(
+            "homeassistant/button/" + remote + "_volup/config", json.dumps(discoveryMsg)
+        )
+        self.subscribe("IR-Remote/" + remote + "/volup/set")
+
+        # Vol - button
+        discoveryMsg = {
+            "name": "Vol -",
+            "command_topic": "IR-Remote/" + remote + "/voldwn/set",
+            "payload_press": "" + remote + ":Vol -",
+            "unique_id": "voldwn_" + remote + "",
             "icon": "mdi:volume-minus",
-            "device": {
-                
-                "identifiers": remote
-                }
-            } 
-     
-        self.publish("homeassistant/button/"+remote+"_voldwn/config", json.dumps(discoveryMsg))
-        self.subscribe("IR-Remote/"+remote+"/voldwn/set")
+            "device": {"identifiers": remote},
+        }
 
-        #mute button
-        discoveryMsg = {"name": "Mute",
-            "command_topic":"IR-Remote/"+remote+"/mute/set",
-            "payload_press":""+remote+":Mute",
-            "unique_id":"mute_"+remote+"",
+        self.publish(
+            "homeassistant/button/" + remote + "_voldwn/config",
+            json.dumps(discoveryMsg),
+        )
+        self.subscribe("IR-Remote/" + remote + "/voldwn/set")
+
+        # mute button
+        discoveryMsg = {
+            "name": "Mute",
+            "command_topic": "IR-Remote/" + remote + "/mute/set",
+            "payload_press": "" + remote + ":Mute",
+            "unique_id": "mute_" + remote + "",
             "icon": "mdi:volume-mute",
-            "device": {
-                
-                "identifiers": remote
-                }
-            } 
-        
-        self.publish("homeassistant/button/"+remote+"_mute/config", json.dumps(discoveryMsg))
-        self.subscribe("IR-Remote/"+remote+"/mute/set")
+            "device": {"identifiers": remote},
+        }
 
-        #Info button
-        discoveryMsg = {"name": "Info",
-            "command_topic":"IR-Remote/"+remote+"/info/set",
-            "payload_press":""+remote+":Info",
-            "unique_id":"info_"+remote+"",
+        self.publish(
+            "homeassistant/button/" + remote + "_mute/config", json.dumps(discoveryMsg)
+        )
+        self.subscribe("IR-Remote/" + remote + "/mute/set")
+
+        # Info button
+        discoveryMsg = {
+            "name": "Info",
+            "command_topic": "IR-Remote/" + remote + "/info/set",
+            "payload_press": "" + remote + ":Info",
+            "unique_id": "info_" + remote + "",
             "icon": "mdi:information-variant",
-            "device": {
-                "name": remote,
-                "identifiers": remote
-                }
-            } 
-        
-        self.publish("homeassistant/button/"+remote+"_info/config", json.dumps(discoveryMsg))
-        self.subscribe("IR-Remote/"+remote+"/info/set")
+            "device": {"name": remote, "identifiers": remote},
+        }
 
+        self.publish(
+            "homeassistant/button/" + remote + "_info/config", json.dumps(discoveryMsg)
+        )
+        self.subscribe("IR-Remote/" + remote + "/info/set")
 
     def remoteHass(self):
         self.remoteLog.info("-------Start MQTT Discovery-------")
@@ -174,37 +176,35 @@ class remoteMqtt:
                 "identifiers": ["test_tv"],
                 "manufacturer": "Example Manufacturer",
                 "model": "Model XYZ",
-                "name": "Test TV"
-                }
-            }
-        self.publish("homeassistant/media_player/test_tv/config", json.dumps(remoteDiscovery))
+                "name": "Test TV",
+            },
+        }
+        self.publish(
+            "homeassistant/media_player/test_tv/config", json.dumps(remoteDiscovery)
+        )
         self.subscribe("IR-Remote/test_tv/set")
 
+    def publish(self, topic, msg):
+        config = json.loads(msg)
+        # self.remoteLog.info("-------MQTT Publish-------")
+        # self.remoteLog.info("Topic: "+config['name']+"")
+        self.client.publish(topic, msg, qos=2, retain=False)
+        # self.remoteLog.info("Published Successfully" )
 
-        
-    def publish(self, topic, msg):           
-            config = json.loads(msg) 
-            #self.remoteLog.info("-------MQTT Publish-------")
-            #self.remoteLog.info("Topic: "+config['name']+"")
-            self.client.publish(topic, msg, qos=2, retain=False)
-            #self.remoteLog.info("Published Successfully" )
-            
     def subscribe(self, topic):
-        #self.remoteLog.info("-------MQTT Subscribe-------")
-        #self.remoteLog.info("Topic: "+topic+"")
+        # self.remoteLog.info("-------MQTT Subscribe-------")
+        # self.remoteLog.info("Topic: "+topic+"")
         self.client.subscribe(topic, 1)
-        #self.remoteLog.info("Subscribed Successfully")
+        # self.remoteLog.info("Subscribed Successfully")
 
     def on_connect(self, client, userdata, flags, rc):
         if rc == 0:
-            self.client.connected_flag=True
+            self.client.connected_flag = True
             self.remoteLog.info("Connected to MQTT Broker Successfully")
         else:
-            self.client.bad_connection_flag=True
+            self.client.bad_connection_flag = True
             print("Failed to connect, return code %d\n", rc)
             self.remoteLog.info("-------Failed to connect-------")
 
     def on_disconnect(self, client, userdata, rc):
         self.remoteLog.info(rc)
-
-    

--- a/ir_remote/remote.py
+++ b/ir_remote/remote.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python3
 
-import os, time, sys, json
+import os
+import time
+import sys
+import json
 
 try:
     from pathlib import Path
@@ -11,81 +14,76 @@ except Exception as ex:
 
 
 class activeRemote:
-
-    def __init__(self, config):        
+    def __init__(self, config):
         self.remoteLog = remoteLog()
         self.activeConfig = config
-        self.active = self.activeConfig['name']
+        self.active = self.activeConfig["name"]
         self.remoteLog.info("-------Loading active remote-------")
-        self.remoteLog.info("Loaded: "+self.active+"")
+        self.remoteLog.info("Loaded: " + self.active + "")
 
-
-        
     def keyPress(self, key):
-        return key  
+        return key
 
     def updateConfig(self, device, data):
         self.remoteLog.info("-------Updating Config-------")
         return device, data
-    
+
     def switchDevice(self, name):
         self.remoteLog.info("-------Switching active remote-------")
         return name
-    
+
+
 class remote:
-
     def __init__(self):
-
-        #load remote log
+        # load remote log
         self.remoteLog = remoteLog()
-        
-        #load master config
+
+        # load master config
         self.root = Path(__file__).parents[1]
-        self.masterPath = self.root / "irMasterConfig.json"    
+        self.masterPath = self.root / "irMasterConfig.json"
         file = open(self.masterPath, "r")
         self.masterConfig = json.load(file)
         file.close()
         self.activeConfig = {}
 
-        #configure buttons from master config 
-        self.activeConfig['btns'] = self.masterConfig['btns']
+        # configure buttons from master config
+        self.activeConfig["btns"] = self.masterConfig["btns"]
 
-        #check config directory exists
-        configDir = "config" 
+        # check config directory exists
+        configDir = "config"
         configPath = self.root / configDir
-        Path(configPath).mkdir(parents=True, exist_ok=True) 
+        Path(configPath).mkdir(parents=True, exist_ok=True)
 
         self.activeFile = "config/activeDevice.json"
         self.activePath = self.root / self.activeFile
-        self.remoteLog.info( self.activePath)
+        self.remoteLog.info(self.activePath)
         active = {}
-        
+
         if self.activePath.is_file():
             file = open(self.activePath, "r")
             active = json.load(file)
             file.close()
-            self.active = active['name']
+            self.active = active["name"]
         else:
-            active['name'] = "None"
+            active["name"] = "None"
             with open(self.activePath, "w") as f:
                 json.dump(active, f)
                 f.close()
-            self.active = active['name']
+            self.active = active["name"]
 
-        #get device list
+        # get device list
         self.deviceList = self.list()
         self.remoteLog.info("Loaded remotes: %s" % self.deviceList)
         if len(self.deviceList) == 0:
             self.remoteLog.info("No Config files installed")
             exit()
         else:
-            self.activeConfig['devices'] = self.deviceList
+            self.activeConfig["devices"] = self.deviceList
         if self.active == "None":
             self.active = self.deviceList[0]
             self.remoteLog.info("Set Remote: %s" % self.active)
-        
-        self.load(self.active)
 
+        self.load(self.active)
 
     def list(self):
         path = self.root / "devices.txt"
@@ -93,18 +91,17 @@ class remote:
         list = os.system('irsend LIST "" "" > %s' % path)
         with open(path, "r") as d:
             for line in d:
-                x = line.split(' ', 1)[-1]                
+                x = line.split(" ", 1)[-1]
                 x = x.replace("\n", "")
                 x = x.strip()
                 if len(x) >= 2:
-                    deviceList.append(x) 
+                    deviceList.append(x)
 
         os.system("rm %s" % path)
-        return(deviceList)
-        
+        return deviceList
 
     def load(self, active):
-        #load devices
+        # load devices
         for device in self.deviceList:
             file = "config/%s.json" % device
             path = self.root / file
@@ -114,49 +111,46 @@ class remote:
                 self.add(device)
 
         self.active = active
-        
+
         self.activeConfigFile = "config/%s.json" % self.active
-        self.activeConfigPath = self.root / self.activeConfigFile       
+        self.activeConfigPath = self.root / self.activeConfigFile
         if self.activeConfigPath.is_file():
             self.setActive()
         else:
             self.add(device)
             self.setActive()
-        
 
-    def setActive(self): 
+    def setActive(self):
         file = open(self.activeConfigPath)
         config = json.load(file)
-        self.activeConfig['name'] = self.active 
-        self.activeConfig['make'] = self.active.split('_', 1)[0]
-        self.activeConfig['model'] = self.active.split('_', 1)[-1]  
+        self.activeConfig["name"] = self.active
+        self.activeConfig["make"] = self.active.split("_", 1)[0]
+        self.activeConfig["model"] = self.active.split("_", 1)[-1]
         keys = self.getKeys(self.active)
-        self.activeConfig['option'] = keys
-        #assign buttons
-        for btn in self.activeConfig['btns'] :
-            data = config['btns'][btn]['key']
-            pulse = config['btns'][btn]['pulse']                   
-            if pulse == 'on':
-                self.activeConfig['btns'][btn]['pulse'] = "long"
+        self.activeConfig["option"] = keys
+        # assign buttons
+        for btn in self.activeConfig["btns"]:
+            data = config["btns"][btn]["key"]
+            pulse = config["btns"][btn]["pulse"]
+            if pulse == "on":
+                self.activeConfig["btns"][btn]["pulse"] = "long"
             else:
-                self.activeConfig['btns'][btn]['pulse'] = "short" 
-            self.activeConfig['btns'][btn]['key'] = data 
-        self.activeConfig['pulseLength'] = config['pulseLength'] 
+                self.activeConfig["btns"][btn]["pulse"] = "short"
+            self.activeConfig["btns"][btn]["key"] = data
+        self.activeConfig["pulseLength"] = config["pulseLength"]
         self.activeRemote = activeRemote(self.activeConfig)
-        #self.remoteLog.info("Buttons Assigned Successfully") 
-        self.getKeys(self.active)     
+        # self.remoteLog.info("Buttons Assigned Successfully")
+        self.getKeys(self.active)
 
-        #save active device name
-        #self.updateMaster()   
-        self.updateActive()  
-                     
+        # save active device name
+        # self.updateMaster()
+        self.updateActive()
+
     def add(self, device):
-         
-
-        #initial button config
-        btns = self.activeConfig['btns']
+        # initial button config
+        btns = self.activeConfig["btns"]
         keys = self.getKeys(device)
-        #keys = self.activeConfig['option']
+        # keys = self.activeConfig['option']
         for btn in btns:
             for key in keys:
                 vu = "VOLUMEUP"
@@ -166,81 +160,80 @@ class remote:
                 prefix = "KEY_%s" % (btn)
                 prefix = prefix.upper()
                 if prefix in key:
-                    btns[btn]['key'] = key
-                    
-                elif btn in key and btns[btn]['key'] == '':
-                    btns[btn]['key'] = key 
+                    btns[btn]["key"] = key
+
+                elif btn in key and btns[btn]["key"] == "":
+                    btns[btn]["key"] = key
                 elif vu in key:
-                    btns['Vol +']['key'] = key
+                    btns["Vol +"]["key"] = key
                 elif vd in key:
-                    btns['Vol -']['key'] = key
+                    btns["Vol -"]["key"] = key
                 elif chu in key:
-                    btns['Ch +']['key'] = key
+                    btns["Ch +"]["key"] = key
                 elif chd in key:
-                    btns['Ch -']['key'] = key
+                    btns["Ch -"]["key"] = key
         config = {}
-        config['btns'] = btns
-        config['option'] = keys
-        config['pulseLength'] = "2"
+        config["btns"] = btns
+        config["option"] = keys
+        config["pulseLength"] = "2"
         self.update(device, config)
 
     def send(self, device, key):
-        #self.remoteLog.info(""+device+" "+key+"")
-        
-        #get code from keypress
+        # self.remoteLog.info(""+device+" "+key+"")
+
+        # get code from keypress
         configFile = "config/%s.json" % device
         path = self.root / configFile
         file = open(path, "r")
         config = json.load(file)
 
-        k = config['btns'][key]['key']
-        p = config['btns'][key]['pulse'] 
+        k = config["btns"][key]["key"]
+        p = config["btns"][key]["pulse"]
         if p == "long":
-            l = int(self.config['pulseLength']) 
+            l = int(self.config["pulseLength"])
         else:
-            l = 0   
-        #os.system('irsend SEND_START %s %s'%(self.active, self.activeConfig['btns'][key]['key']))
-        os.system('irsend SEND_START %s %s'%(device, k))
+            l = 0
+        # os.system('irsend SEND_START %s %s'%(self.active, self.activeConfig['btns'][key]['key']))
+        os.system("irsend SEND_START %s %s" % (device, k))
         time.sleep(l)
-        #os.system('irsend SEND_STOP %s %s'%(self.active, self.activeConfig['btns'][key]['key']))
-        os.system('irsend SEND_STOP %s %s'%(device, k))
-        #self.remoteLog.info("IR Signal Sent for: "+self.active+" "+self.activeConfig['btns'][key]['key']+"")
-        self.remoteLog.info("IR Signal Sent for: "+device+" "+k+"")
+        # os.system('irsend SEND_STOP %s %s'%(self.active, self.activeConfig['btns'][key]['key']))
+        os.system("irsend SEND_STOP %s %s" % (device, k))
+        # self.remoteLog.info("IR Signal Sent for: "+self.active+" "+self.activeConfig['btns'][key]['key']+"")
+        self.remoteLog.info("IR Signal Sent for: " + device + " " + k + "")
 
     def update(self, device, data):
         config = {}
-        config['btns'] = data['btns']
-        config['pulseLength'] = data['pulseLength']
+        config["btns"] = data["btns"]
+        config["pulseLength"] = data["pulseLength"]
         file = "config/%s.json" % device
         path = self.root / file
         with open(path, "w") as f:
             json.dump(config, f)
         self.remoteLog.info("Buttons Updated")
-        
+
     def updateActive(self):
-        #set active remote
+        # set active remote
         file = open(self.activePath, "r")
         active = json.load(file)
-        active['name'] = self.active
+        active["name"] = self.active
         with open(self.activePath, "w") as f:
             json.dump(active, f)
         self.remoteLog.info("-------Active Device Updated-------")
 
     def getKeys(self, device):
-        #load keys codes
+        # load keys codes
         keyPath = self.root / "key_list.txt"
         get_list = 'irsend LIST %s "" > %s' % (device, keyPath)
         list = os.system(get_list)
-        #store key codes
+        # store key codes
         keys = []
         with open(keyPath, "r") as rc:
             for line in rc:
-                x = line.split(' ', 1)[-1]
+                x = line.split(" ", 1)[-1]
                 x = x.replace("\n", "")
                 x = x.strip()
                 keys.append(x)
             os.system("rm %s" % keyPath)
 
         return keys
-        #self.activeConfig['option'] = keys  
-
+        # self.activeConfig['option'] = keys

--- a/ir_remote/remotelog.py
+++ b/ir_remote/remotelog.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
-import sys, logging
+import sys
+import logging
 
 try:
     from pathlib import Path
@@ -12,28 +13,26 @@ root = Path(__file__).parents[1]
 logPath = root / "irRemote.log"
 log_format = "%(asctime)s - %(levelname)s - %(module)s - %(lineno)d - %(message)s"
 date_format = "%Y-%m-%d %H:%M:%S"
-logging.basicConfig(filename=logPath, level=logging.DEBUG, format=log_format, datefmt=date_format)
+logging.basicConfig(
+    filename=logPath, level=logging.DEBUG, format=log_format, datefmt=date_format
+)
+
 
 class remoteLog:
-
     def __init__(self):
         self.logger = logging.getLogger(__name__)
 
-
     def debug(self, msg):
         self.logger.debug(msg)
-        
 
     def info(self, msg):
         self.logger.info(msg)
-        
+
     def warning(self, msg):
         self.logger.warning(msg)
-        
-        
+
     def error(self, msg):
         self.logger.error(msg)
-
 
     def critical(self, msg):
         self.logger.critical(msg)
@@ -48,11 +47,10 @@ class remoteLog:
         fileContent = []
         with open(logPath, "r") as data:
             for line in data:
-                #logData['data'] = line
-                fileContent.append(line)    
+                # logData['data'] = line
+                fileContent.append(line)
         logData = {}
         fileContent = fileContent[-100:]
         fileContent.reverse()
-        logData['data'] = fileContent
+        logData["data"] = fileContent
         return logData
-

--- a/ir_remote/webserver.py
+++ b/ir_remote/webserver.py
@@ -1,11 +1,10 @@
 #!/usr/bin/python3
 
-import sys, json, os, fileinput
+import sys
 
 
 try:
     from flask import Flask, render_template, request
-    from flask_restful import Api, Resource
     from pathlib import Path
     from remotelog import remoteLog
 except Exception as ex:
@@ -16,55 +15,51 @@ except Exception as ex:
 class flaskWrapper:
     def __init__(self, remote):
         self.remoteLog = remoteLog()
-        self.remote = remote  
-           
-    def main(self):         
+        self.remote = remote
+
+    def main(self):
         key = ""
         if request.method == "POST":
-            key = request.form.get('button') 
+            key = request.form.get("button")
             self.remote.keyPress(key)
-            key = ""                 
-            return render_template('main.html', **self.remote.activeConfig) 
-          
-        if request.method == "GET":      
-            return render_template('main.html', **self.remote.activeConfig)
-        
-    def settings(self):       
+            key = ""
+            return render_template("main.html", **self.remote.activeConfig)
+
+        if request.method == "GET":
+            return render_template("main.html", **self.remote.activeConfig)
+
+    def settings(self):
         if request.method == "POST":
-            r = request.form.get('devices')
-            p = request.form.get('pulseLength')
-            if r == self.remote.active:           
-                self.remote.activeConfig['pulseLength'] = p   
-                for btn in self.remote.activeConfig['btns'] :
-                    data = request.form.get('%s' % (btn))
-                    pulse = request.form.get('%s_pulse' % (btn))                    
-                    if pulse == 'on':
-                        self.remote.activeConfig['btns'][btn]['pulse'] = "long"
+            r = request.form.get("devices")
+            p = request.form.get("pulseLength")
+            if r == self.remote.active:
+                self.remote.activeConfig["pulseLength"] = p
+                for btn in self.remote.activeConfig["btns"]:
+                    data = request.form.get("%s" % (btn))
+                    pulse = request.form.get("%s_pulse" % (btn))
+                    if pulse == "on":
+                        self.remote.activeConfig["btns"][btn]["pulse"] = "long"
                     else:
-                        self.remote.activeConfig['btns'][btn]['pulse'] = "short" 
-                    self.remote.activeConfig['btns'][btn]['key'] = data         
-                self.remote.updateConfig(self.remote.active, self.remote.activeConfig)                 
+                        self.remote.activeConfig["btns"][btn]["pulse"] = "short"
+                    self.remote.activeConfig["btns"][btn]["key"] = data
+                self.remote.updateConfig(self.remote.active, self.remote.activeConfig)
             else:
                 self.remote.active = r
-                self.remote.switchDevice(self.remote.active)                       
-            return render_template('main.html', **self.remote.activeConfig)
-        
-        if request.method == "GET":       
-            return render_template('settings.html', **self.remote.activeConfig)
-        
+                self.remote.switchDevice(self.remote.active)
+            return render_template("main.html", **self.remote.activeConfig)
+
+        if request.method == "GET":
+            return render_template("settings.html", **self.remote.activeConfig)
 
     def log(self):
-
-
         if request.method == "POST":
-            self.remoteLog.resetLog()    
+            self.remoteLog.resetLog()
             logData = self.remoteLog.getLog()
-            return render_template('log.html', **logData)
-          
+            return render_template("log.html", **logData)
+
         if request.method == "GET":
             logData = self.remoteLog.getLog()
-            return render_template('log.html', **logData)
-
+            return render_template("log.html", **logData)
 
     def run(self):
         self.remoteLog.info("-------Loading Webserver-------")
@@ -75,5 +70,4 @@ class flaskWrapper:
         self.app.route("/settings.html", methods=["GET", "POST"])(self.settings)
         self.app.route("/log.html", methods=["GET", "POST"])(self.log)
         self.remoteLog.info("Webserver Loaded Successfully")
-        self.app.run(host='0.0.0.0', port=8081, debug=True)
-
+        self.app.run(host="0.0.0.0", port=8081, debug=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,13 @@ requires-python = ">=3.9,<4.0"
 dependencies = [
     "flask",
     "flask-restful",
-    "paho-mqtt"
+    "paho-mqtt",
+]
+
+[tool.uv]
+dev-dependencies = [
+    "pre-commit>=4.0.1",
+    "ruff>=0.7.1",
 ]
 
 [project.scripts]
@@ -18,3 +24,39 @@ ir-remote = "ir_remote.launchremote:run"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.ruff]
+target-version = "py39"
+
+[tool.ruff.format]
+# Auto picks the first line ending encountered in a file
+# Change to lf or cr-lf as required
+line-ending = "auto"
+
+[tool.ruff.lint]
+select = [
+  "F",  # pyflakes
+  "E4", "E7", "E9"
+  #"E",  # pycodestyle errors
+  # Can be enabled selectively
+  #"W", # pycodestyle warnings
+  #"D",  # pydocstyle
+  #"UP",  # pyupgrade
+  #"B",  # flake8-bugbear
+  #"SIM",  # flake8-simplify
+  #"FA", # flake8-future-annotations
+  #"I",  # isort
+  #"S",  # bandit
+  #"PT",  # flake8-pytest-style
+  #"LOG",  # flake8-logging
+  #"G",  # flake8-logging-format
+]
+
+ignore = [
+  "D105",  # Missing docstring in magic method
+  "D107",  # Missing docstring in `__init__`
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "pep257"
+

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249 },
+]
+
+[[package]]
 name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
@@ -38,6 +47,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "distlib"
+version = "0.3.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973 },
+]
+
+[[package]]
+name = "filelock"
+version = "3.16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/db/3ef5bb276dae18d6ec2124224403d1d67bccdbefc17af4cc8f553e341ab1/filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435", size = 18037 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/f8/feced7779d755758a52d1f6635d990b8d98dc0a29fa568bbe0625f18fdf3/filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0", size = 16163 },
 ]
 
 [[package]]
@@ -73,6 +100,15 @@ wheels = [
 ]
 
 [[package]]
+name = "identify"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/bb/25024dbcc93516c492b75919e76f389bac754a3e4248682fba32b250c880/identify-2.6.1.tar.gz", hash = "sha256:91478c5fb7c3aac5ff7bf9b4344f803843dc586832d5f110d672b19aa1984c98", size = 99097 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/0c/4ef72754c050979fdcc06c744715ae70ea37e734816bb6514f79df77a42f/identify-2.6.1-py2.py3-none-any.whl", hash = "sha256:53863bcac7caf8d2ed85bd20312ea5dcfc22226800f6d6881f232d861db5a8f0", size = 98972 },
+]
+
+[[package]]
 name = "importlib-metadata"
 version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -94,11 +130,23 @@ dependencies = [
     { name = "paho-mqtt" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pre-commit" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "flask" },
     { name = "flask-restful" },
     { name = "paho-mqtt" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pre-commit", specifier = ">=4.0.1" },
+    { name = "ruff", specifier = ">=0.7.1" },
 ]
 
 [[package]]
@@ -191,12 +239,46 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "paho-mqtt"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/39/15/0a6214e76d4d32e7f663b109cf71fb22561c2be0f701d67f93950cd40542/paho_mqtt-2.1.0.tar.gz", hash = "sha256:12d6e7511d4137555a3f6ea167ae846af2c7357b10bc6fa4f7c3968fc1723834", size = 148848 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/cb/00451c3cf31790287768bb12c6bec834f5d292eaf3022afc88e14b8afc94/paho_mqtt-2.1.0-py3-none-any.whl", hash = "sha256:6db9ba9b34ed5bc6b6e3812718c7e06e2fd7444540df2455d2c51bd58808feee", size = 67219 },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.3.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907", size = 21302 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb", size = 18439 },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c8/e22c292035f1bac8b9f5237a2622305bc0304e776080b246f3df57c4ff9f/pre_commit-4.0.1.tar.gz", hash = "sha256:80905ac375958c0444c65e9cebebd948b3cdb518f335a091a670a89d652139d2", size = 191678 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/8f/496e10d51edd6671ebe0432e33ff800aa86775d2d147ce7d43389324a525/pre_commit-4.0.1-py2.py3-none-any.whl", hash = "sha256:efde913840816312445dc98787724647c65473daefe420785f885e8ed9a06878", size = 218713 },
 ]
 
 [[package]]
@@ -209,12 +291,104 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/95/a3fac87cb7158e231b5a6012e438c647e1a87f09f8e0d123acec8ab8bf71/PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086", size = 184199 },
+    { url = "https://files.pythonhosted.org/packages/c7/7a/68bd47624dab8fd4afbfd3c48e3b79efe09098ae941de5b58abcbadff5cb/PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf", size = 171758 },
+    { url = "https://files.pythonhosted.org/packages/49/ee/14c54df452143b9ee9f0f29074d7ca5516a36edb0b4cc40c3f280131656f/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237", size = 718463 },
+    { url = "https://files.pythonhosted.org/packages/4d/61/de363a97476e766574650d742205be468921a7b532aa2499fcd886b62530/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b", size = 719280 },
+    { url = "https://files.pythonhosted.org/packages/6b/4e/1523cb902fd98355e2e9ea5e5eb237cbc5f3ad5f3075fa65087aa0ecb669/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed", size = 751239 },
+    { url = "https://files.pythonhosted.org/packages/b7/33/5504b3a9a4464893c32f118a9cc045190a91637b119a9c881da1cf6b7a72/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180", size = 695802 },
+    { url = "https://files.pythonhosted.org/packages/5c/20/8347dcabd41ef3a3cdc4f7b7a2aff3d06598c8779faa189cdbf878b626a4/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68", size = 720527 },
+    { url = "https://files.pythonhosted.org/packages/be/aa/5afe99233fb360d0ff37377145a949ae258aaab831bde4792b32650a4378/PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99", size = 144052 },
+    { url = "https://files.pythonhosted.org/packages/b5/84/0fa4b06f6d6c958d207620fc60005e241ecedceee58931bb20138e1e5776/PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e", size = 161774 },
+    { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612 },
+    { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040 },
+    { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829 },
+    { url = "https://files.pythonhosted.org/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167 },
+    { url = "https://files.pythonhosted.org/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952 },
+    { url = "https://files.pythonhosted.org/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301 },
+    { url = "https://files.pythonhosted.org/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638 },
+    { url = "https://files.pythonhosted.org/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850 },
+    { url = "https://files.pythonhosted.org/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980 },
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873 },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302 },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154 },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223 },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542 },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164 },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611 },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591 },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338 },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309 },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679 },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428 },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361 },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523 },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660 },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
+    { url = "https://files.pythonhosted.org/packages/65/d8/b7a1db13636d7fb7d4ff431593c510c8b8fca920ade06ca8ef20015493c5/PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d", size = 184777 },
+    { url = "https://files.pythonhosted.org/packages/0a/02/6ec546cd45143fdf9840b2c6be8d875116a64076218b61d68e12548e5839/PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f", size = 172318 },
+    { url = "https://files.pythonhosted.org/packages/0e/9a/8cc68be846c972bda34f6c2a93abb644fb2476f4dcc924d52175786932c9/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290", size = 720891 },
+    { url = "https://files.pythonhosted.org/packages/e9/6c/6e1b7f40181bc4805e2e07f4abc10a88ce4648e7e95ff1abe4ae4014a9b2/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12", size = 722614 },
+    { url = "https://files.pythonhosted.org/packages/3d/32/e7bd8535d22ea2874cef6a81021ba019474ace0d13a4819c2a4bce79bd6a/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19", size = 737360 },
+    { url = "https://files.pythonhosted.org/packages/d7/12/7322c1e30b9be969670b672573d45479edef72c9a0deac3bb2868f5d7469/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e", size = 699006 },
+    { url = "https://files.pythonhosted.org/packages/82/72/04fcad41ca56491995076630c3ec1e834be241664c0c09a64c9a2589b507/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725", size = 723577 },
+    { url = "https://files.pythonhosted.org/packages/ed/5e/46168b1f2757f1fcd442bc3029cd8767d88a98c9c05770d8b420948743bb/PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631", size = 144593 },
+    { url = "https://files.pythonhosted.org/packages/19/87/5124b1c1f2412bb95c59ec481eaf936cd32f0fe2a7b16b97b81c4c017a6a/PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8", size = 162312 },
+]
+
+[[package]]
+name = "ruff"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/21/5c6e05e0fd3fbb41be4fb92edbc9a04de70baf60adb61435ce0c6b8c3d55/ruff-0.7.1.tar.gz", hash = "sha256:9d8a41d4aa2dad1575adb98a82870cf5db5f76b2938cf2206c22c940034a36f4", size = 3181670 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/45/8a20a9920175c9c4892b2420f80ff3cf14949cf3067118e212f9acd9c908/ruff-0.7.1-py3-none-linux_armv6l.whl", hash = "sha256:cb1bc5ed9403daa7da05475d615739cc0212e861b7306f314379d958592aaa89", size = 10389268 },
+    { url = "https://files.pythonhosted.org/packages/1b/d3/2f8382db2cf4f9488e938602e33e36287f9d26cb283aa31f11c31297ce79/ruff-0.7.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:27c1c52a8d199a257ff1e5582d078eab7145129aa02721815ca8fa4f9612dc35", size = 10188348 },
+    { url = "https://files.pythonhosted.org/packages/a2/31/7d14e2a88da351200f844b7be889a0845d9e797162cf76b136d21b832a23/ruff-0.7.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:588a34e1ef2ea55b4ddfec26bbe76bc866e92523d8c6cdec5e8aceefeff02d99", size = 9841448 },
+    { url = "https://files.pythonhosted.org/packages/db/99/738cafdc768eceeca0bd26c6f03e213aa91203d2278e1d95b1c31c4ece41/ruff-0.7.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94fc32f9cdf72dc75c451e5f072758b118ab8100727168a3df58502b43a599ca", size = 10674864 },
+    { url = "https://files.pythonhosted.org/packages/fe/12/bcf2836b50eab53c65008383e7d55201e490d75167c474f14a16e1af47d2/ruff-0.7.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:985818742b833bffa543a84d1cc11b5e6871de1b4e0ac3060a59a2bae3969250", size = 10192105 },
+    { url = "https://files.pythonhosted.org/packages/2b/71/261d5d668bf98b6c44e89bfb5dfa4cb8cb6c8b490a201a3d8030e136ea4f/ruff-0.7.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:32f1e8a192e261366c702c5fb2ece9f68d26625f198a25c408861c16dc2dea9c", size = 11194144 },
+    { url = "https://files.pythonhosted.org/packages/90/1f/0926d18a3b566fa6e7b3b36093088e4ffef6b6ba4ea85a462d9a93f7e35c/ruff-0.7.1-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:699085bf05819588551b11751eff33e9ca58b1b86a6843e1b082a7de40da1565", size = 11917066 },
+    { url = "https://files.pythonhosted.org/packages/cd/a8/9fac41f128b6a44ab4409c1493430b4ee4b11521e8aeeca19bfe1ce851f9/ruff-0.7.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:344cc2b0814047dc8c3a8ff2cd1f3d808bb23c6658db830d25147339d9bf9ea7", size = 11458821 },
+    { url = "https://files.pythonhosted.org/packages/25/cd/59644168f086ab13fe4e02943b9489a0aa710171f66b178e179df5383554/ruff-0.7.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4316bbf69d5a859cc937890c7ac7a6551252b6a01b1d2c97e8fc96e45a7c8b4a", size = 12700379 },
+    { url = "https://files.pythonhosted.org/packages/fb/30/3bac63619eb97174661829c07fc46b2055a053dee72da29d7c304c1cd2c0/ruff-0.7.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79d3af9dca4c56043e738a4d6dd1e9444b6d6c10598ac52d146e331eb155a8ad", size = 11019813 },
+    { url = "https://files.pythonhosted.org/packages/4b/af/f567b885b5cb3bcdbcca3458ebf210cc8c9c7a9f61c332d3c2a050c3b21e/ruff-0.7.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c5c121b46abde94a505175524e51891f829414e093cd8326d6e741ecfc0a9112", size = 10662146 },
+    { url = "https://files.pythonhosted.org/packages/bc/ad/eb930d3ad117a9f2f7261969c21559ebd82bb13b6e8001c7caed0d44be5f/ruff-0.7.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8422104078324ea250886954e48f1373a8fe7de59283d747c3a7eca050b4e378", size = 10256911 },
+    { url = "https://files.pythonhosted.org/packages/20/d5/af292ce70a016fcec792105ca67f768b403dd480a11888bc1f418fed0dd5/ruff-0.7.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:56aad830af8a9db644e80098fe4984a948e2b6fc2e73891538f43bbe478461b8", size = 10767488 },
+    { url = "https://files.pythonhosted.org/packages/24/85/cc04a3bd027f433bebd2a097e63b3167653c079f7f13d8f9a1178e693412/ruff-0.7.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:658304f02f68d3a83c998ad8bf91f9b4f53e93e5412b8f2388359d55869727fd", size = 11093368 },
+    { url = "https://files.pythonhosted.org/packages/0b/fb/c39cbf32d1f3e318674b8622f989417231794926b573f76dd4d0ca49f0f1/ruff-0.7.1-py3-none-win32.whl", hash = "sha256:b517a2011333eb7ce2d402652ecaa0ac1a30c114fbbd55c6b8ee466a7f600ee9", size = 8594180 },
+    { url = "https://files.pythonhosted.org/packages/5a/71/ec8cdea34ecb90c830ca60d54ac7b509a7b5eab50fae27e001d4470fe813/ruff-0.7.1-py3-none-win_amd64.whl", hash = "sha256:f38c41fcde1728736b4eb2b18850f6d1e3eedd9678c914dede554a70d5241307", size = 9419751 },
+    { url = "https://files.pythonhosted.org/packages/79/7b/884553415e9f0a9bf358ed52fb68b934e67ef6c5a62397ace924a1afdf9a/ruff-0.7.1-py3-none-win_arm64.whl", hash = "sha256:19aa200ec824c0f36d0c9114c8ec0087082021732979a359d6f3c390a6ff2a37", size = 8717402 },
+]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926", size = 34041 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254", size = 11053 },
+]
+
+[[package]]
+name = "virtualenv"
+version = "20.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/7f/192dd6ab6d91ebea7adf6c030eaf549b1ec0badda9f67a77b633602f66ac/virtualenv-20.27.0.tar.gz", hash = "sha256:2ca56a68ed615b8fe4326d11a0dca5dfbe8fd68510fb6c6349163bed3c15f2b2", size = 6483858 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/15/828ec11907aee2349a9342fa71fba4ba7f3af938162a382dd7da339dea16/virtualenv-20.27.0-py3-none-any.whl", hash = "sha256:44a72c29cceb0ee08f300b314848c86e57bf8d1f13107a5e671fb9274138d655", size = 3110969 },
 ]
 
 [[package]]


### PR DESCRIPTION
Enable ruff pre-commit checks.

Install pre-commit:
```bash
uv run pre-commit install
```

All commits will be checked and automatically fixed.

- To enable checks that can't be automatically fixed change the `--fix-only` parameter in `.pre-commit-config.yaml` to `--fix`.
- To preview errors that would need to manually fixed if `--fix-only` was replaced with `--fix` run `uv run ruff check --no-fix`.
- To preview errors that would appear if new rules are enabled in `pyproject.toml` run `uv run ruff check --no-fix --extend-select <COMMA SEPERATED RULE IDS>`
- To have ruff checks appear inline in vscode install the [ruff extension](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff).

Commits:

- **Enable ruff pre-commit check**
- **Run ruff fixes**
